### PR TITLE
Improve checking whether is a subdomain method

### DIFF
--- a/wechatgame/libs/wx-downloader.js
+++ b/wechatgame/libs/wx-downloader.js
@@ -32,7 +32,7 @@ var non_text_format = [
 const REGEX = /^\w+:\/\/.*/;
 
 // has sub domain
-var isSubdomain = wx.getGroupCloudStorage && wx.getFriendCloudStorage;
+var isSubdomain = !wx.getFileSystemManager;
 
 var fs = isSubdomain ? {} : wx.getFileSystemManager();
 


### PR DESCRIPTION
在某些版本下，主域中还是有包含 wx.getGroupCloudStorage && wx.getFriendCloudStorage api 的，所以改为检查 wx.getFileSystemManager 是否可用来确定是否是子域