### PR TITLE
fix multiLine return

### DIFF
--- a/wechatgame/libs/weapp-adapter/engine/Editbox.js
+++ b/wechatgame/libs/weapp-adapter/engine/Editbox.js
@@ -99,7 +99,7 @@
                 defaultValue: editBoxImpl._text,
                 maxLength: editBoxImpl._maxLength,
                 multiple: multiline,
-                confirmHold: true,
+                confirmHold: false,  // hide keyboard mannually by wx.onKeyboardConfirm
                 confirmType: getKeyboardReturnType(editBoxImpl._returnType),
                 success: function (res) {
                     editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingDidBegan && editBoxImpl._delegate.editBoxEditingDidBegan();


### PR DESCRIPTION
Re: cocos-creator/fireball#8063

小游戏 文档里边，confirmHold 是指 点击完成时收起键盘
但是这个参数好像是无效的。。。
我们自己已经在 confirmCallback 里边手动收起键盘了，所以这个参数设为 false 就好了

@pandamicro 