### PR TITLE
fix emit editingDidEnded event twice

### DIFF
--- a/wechatgame/libs/weapp-adapter/engine/Editbox.js
+++ b/wechatgame/libs/weapp-adapter/engine/Editbox.js
@@ -66,7 +66,7 @@
             editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingReturn && editBoxImpl._delegate.editBoxEditingReturn();
             wx.hideKeyboard({
                 success: function (res) {
-                    editBoxImpl._delegate && editBoxImpl._delegate.editBoxEditingDidEnded && editBoxImpl._delegate.editBoxEditingDidEnded();
+                    
                 },
                 fail: function (res) {
                     cc.warn(res.errMsg);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8298

小游戏 onComplete 监听的就是键盘隐藏事件，onComfirm 这里重复监听了。导致 ended 事件 触发两次