### PR TITLE
cancel auto es6 to es5

### DIFF
--- a/wechatgame/libs/wx-downloader.js
+++ b/wechatgame/libs/wx-downloader.js
@@ -29,7 +29,7 @@ var non_text_format = [
     'js','png','jpg','bmp','jpeg','gif','ico','tiff','webp','image','pvr','etc','mp3','ogg','wav','m4a','font','eot','ttf','woff','svg','ttc'
 ];
 
-const REGEX = /^\w+:\/\/.*/;
+var REGEX = /^\w+:\/\/.*/;
 
 // has sub domain
 var isSubdomain = !wx.getFileSystemManager;

--- a/wechatgame/project.config.json
+++ b/wechatgame/project.config.json
@@ -3,7 +3,7 @@
 	"miniprogramRoot": "./",
 	"setting": {
 		"urlCheck": true,
-		"es6": true,
+		"es6": false,
 		"postcss": true,
 		"minified": true,
 		"newFeature": false


### PR DESCRIPTION
- es6 转 es5
- 取消自动 es6 转 es5，，因为有用户反馈转 es5 后 weapp.socket.io 会报错