### PR TITLE
forbid cc.game.end in wechat game platform

### DIFF
--- a/wechatgame/libs/engine/Game.js
+++ b/wechatgame/libs/engine/Game.js
@@ -25,3 +25,5 @@ cc.game._runMainLoop = function () {
     self._intervalId = window.requestAnimFrame(callback);
     self._paused = false;
 };
+// wechat game platform not support this api
+cc.game.end = function () {};


### PR DESCRIPTION
Re: https://github.com/cocos-creator/engine/issues/3369
wechat game 没有设置全局 close 函数，因此改用提示用户无法使用对应 API


web 有自带 close API
native 有 closeWindow API 对应
![image](https://user-images.githubusercontent.com/35832931/47900190-02abe000-deb7-11e8-9a3f-b4849c04b5a2.png)
