### PR TITLE
add the limit for download count

### DIFF
--- a/wechatgame/libs/engine/AudioEngine.js
+++ b/wechatgame/libs/engine/AudioEngine.js
@@ -1,5 +1,0 @@
-(function () {
-    if (cc && cc.audioEngine) {
-        cc.audioEngine._maxAudioInstance = 10;
-    }
-})();

--- a/wechatgame/libs/engine/index.js
+++ b/wechatgame/libs/engine/index.js
@@ -2,4 +2,4 @@ require('./Game');
 require('./Editbox');
 require('./DeviceMotionEvent');
 require('./downloader');
-require('./AudioEngine');
+require('./misc');

--- a/wechatgame/libs/engine/misc.js
+++ b/wechatgame/libs/engine/misc.js
@@ -1,0 +1,7 @@
+// cc.AuidioEngine
+if (cc && cc.audioEngine) {
+    cc.audioEngine._maxAudioInstance = 10;
+}
+
+// cc.Macro
+cc.macro.DOWNLOAD_MAX_CONCURRENT = 10;


### PR DESCRIPTION
1.限制 wehcat 平台最大下载数量为 10
![image](https://user-images.githubusercontent.com/35832931/48409760-bb0b3b00-e777-11e8-9b73-c96345b17dd4.png)
根据反馈微信平台支持的最大下载线程为 10 所以将最大下载线程数由 64 修改为 10
2.并且将原本的 audioEngine 文件进行整合，合并为 misc 文件