### PR TITLE
fix: align to screen and resize widget on sub-domain canvas change size

### DIFF
--- a/wechatgame/libs/sub-context-adapter.js
+++ b/wechatgame/libs/sub-context-adapter.js
@@ -46,6 +46,10 @@ wx.onMessage(function (data) {
 cc.Canvas.prototype.update = function () {
     if (this._width !== cc.game.canvas.width || this._height !== cc.game.canvas.height) {
         this.applySettings();
+        // resize canvas
+        this.alignWithScreen();
+        // resize ui widgets
+        cc._widgetManager.onResized();
     }
 };
 


### PR DESCRIPTION
使用Creator创建子域项目后设置Canvas为fit Height，开发工具与真机测试时发现，当主域改变sharedCanvas大小后子域并没有按照FixHeight的策略进行适配。这个RP是真机与开发工具测试均通过了的修复方案（适合当前2.1.0版本Creator）。