### PR TITLE
revert adjust the timing of do preload pack

### DIFF
--- a/wechatgame/libs/sub-context-adapter.js
+++ b/wechatgame/libs/sub-context-adapter.js
@@ -1,6 +1,6 @@
 var settings = window._CCSettings;
 
-cc.game.once(cc.game.EVENT_ENGINE_INITED, function () {
+cc.director.once(cc.Director.EVENT_BEFORE_SCENE_LOADING, function () {
     cc.Pipeline.Downloader.PackDownloader._doPreload("WECHAT_SUBDOMAIN", settings.WECHAT_SUBDOMAIN_DATA);
 });
 


### PR DESCRIPTION
由于 2.0-release 分支 PackDownloader.initPacks 在 initEngine 之后导致， PackDownloader._doPreload 失败，所以进行回退 