### PR TITLE
add audio stop fix 2d-tasks/issues/1447

### DIFF
--- a/wechatgame/libs/engine/Audio.js
+++ b/wechatgame/libs/engine/Audio.js
@@ -1,0 +1,9 @@
+
+
+cc.Audio.prototype.stop = function () {
+    if (!this._element) return;
+    this._element.stop();
+    this._unbindEnded();
+    this.emit('stop');
+    this._state = cc.Audio.State.STOPPED;
+};

--- a/wechatgame/libs/engine/index.js
+++ b/wechatgame/libs/engine/index.js
@@ -1,4 +1,5 @@
 require('./Game');
+require('./Audio');
 require('./Editbox');
 require('./DeviceMotionEvent');
 require('./downloader');

--- a/wechatgame/libs/weapp-adapter/Audio.js
+++ b/wechatgame/libs/weapp-adapter/Audio.js
@@ -104,6 +104,10 @@ export default class Audio extends HTMLAudioElement {
     _innerAudioContextMap[this._$sn].pause()
   }
 
+  stop() {
+      _innerAudioContextMap[this._$sn].stop()
+  }
+
   destroy() {
     _innerAudioContextMap[this._$sn].destroy()
   }


### PR DESCRIPTION
相关 issue：https://github.com/cocos-creator/2d-tasks/issues/1447

修改 stop 函数，直接调用微信小游戏的 stop 即可，之前的 stop 是先 pause 音频，然后设置 crrentTime 为 0，这个方法不适用于微信小游戏会变成 stop 后，获取 crrrentTime 还是原来的数值，不会归 0