### PR TITLE
fix issue that loadRes doesn't callback

### DIFF
--- a/wechatgame/libs/engine/downloader.js
+++ b/wechatgame/libs/engine/downloader.js
@@ -22,8 +22,64 @@ function loadFont (item) {
     return fontFamily || 'Arial';
 }
 
+function downloadImage (item, callback, isCrossOrigin) {
+    if (isCrossOrigin === undefined) {
+        isCrossOrigin = true;
+    }
+
+    var url = item.url;
+    var img = new Image();
+    if (isCrossOrigin && window.location.protocol !== 'file:') {
+        img.crossOrigin = 'anonymous';
+    }
+    else {
+        img.crossOrigin = null;
+    }
+
+    function loadCallback () {
+        img.removeEventListener('load', loadCallback);
+        img.removeEventListener('error', errorCallback);
+
+        img.id = item.id;
+        callback(null, img);
+    }
+    function errorCallback () {
+        img.removeEventListener('load', loadCallback);
+        img.removeEventListener('error', errorCallback);
+
+        // Retry without crossOrigin mark if crossOrigin loading fails
+        // Do not retry if protocol is https, even if the image is loaded, cross origin image isn't renderable.
+        if (window.location.protocol !== 'https:' && img.crossOrigin && img.crossOrigin.toLowerCase() === 'anonymous') {
+            downloadImage(item, callback, false);
+        }
+        else {
+            callback(new Error(cc.debug.getError(4930, url)));
+        }
+    }
+
+    img.addEventListener('load', loadCallback);
+    img.addEventListener('error', errorCallback);
+    img.src = url;
+}
+
+function downloadWebp (item, callback) {
+    if (!cc.sys.capabilities.webp) {
+        return new Error(cc.debug.getError(4929, item.url));
+    }
+    return downloadImage(item, callback);
+}
+
 cc.loader.downloader.addHandlers({
-    js : downloadScript
+    js : downloadScript,
+    png : downloadImage,
+    jpg : downloadImage,
+    bmp : downloadImage,
+    jpeg : downloadImage,
+    gif : downloadImage,
+    ico : downloadImage,
+    tiff : downloadImage,
+    webp : downloadWebp,
+    image : downloadImage
 });
 
 cc.loader.loader.addHandlers({

--- a/wechatgame/libs/wx-downloader.js
+++ b/wechatgame/libs/wx-downloader.js
@@ -293,12 +293,12 @@ function cacheFile (url, isCopy, cachePath) {
                         }
                         cachedFiles[item.cachePath] = 1;
                         writeCacheFile();
+                        if (!cc.js.isEmptyObject(cacheQueue) && !checkNextPeriod) {
+                            checkNextPeriod = true;
+                            setTimeout(cache, wxDownloader.cachePeriod);
+                        }
                     });
                     delete cacheQueue[srcUrl];
-                }
-                if (!cc.js.isEmptyObject(cacheQueue) && !checkNextPeriod) {
-                    checkNextPeriod = true;
-                    setTimeout(cache, wxDownloader.cachePeriod);
                 }
                 return;
             }


### PR DESCRIPTION
修复微信下载远程图片导致后续加载资源没有回调的问题
修改缓存时机，改为上个资源缓存完成后等待一段时间缓存下个资源，避免有些资源过大，缓存太久，占用下次缓存的时间