### PR TITLE
fix issue that fail to load large file as json

### DIFF
--- a/wechatgame/libs/wx-downloader.js
+++ b/wechatgame/libs/wx-downloader.js
@@ -360,18 +360,33 @@ function downloadRemoteFile (item, callback) {
 }
 
 var callbacks = [];
+var nextCallbacks = [];
+var startWrite = false;
 function writeCacheFile (cb) {
-    cb && callbacks.push(cb);
     function write () {
+        writeCacheFileList = null;
+        startWrite = true;
         wxFsUtils.writeFile(wxDownloader.cacheDir + '/' + wxDownloader.cachedFileName, JSON.stringify(cachedFiles), 'utf8', function () {
-            writeCacheFileList = null;
+            startWrite = false;
             for (let i = 0, j = callbacks.length; i < j; i++) {
                 callbacks[i]();
             }
             callbacks.length = 0;
+            callbacks.push.apply(callbacks, nextCallbacks);
+            nextCallbacks.length = 0;
         });
     }
-    !writeCacheFileList && (writeCacheFileList = setTimeout(write, wxDownloader.writeFilePeriod));
+    if (!writeCacheFileList) {
+        writeCacheFileList = setTimeout(write, wxDownloader.writeFilePeriod);
+        if (startWrite === true) {
+            cb && nextCallbacks.push(cb);
+        }
+        else {
+            cb && callbacks.push(cb);
+        }
+    } else {
+        cb && callbacks.push(cb);
+    }
 }
 
 function shouldReadFile (type) {

--- a/wechatgame/libs/wx-fs-utils.js
+++ b/wechatgame/libs/wx-fs-utils.js
@@ -61,10 +61,12 @@ function downloadFile (remoteUrl, filePath, callback) {
                     deleteFile(res.filePath);
                 }
                 console.warn("Download file failed: " + remoteUrl);
+                console.warn(res.errMsg);
                 callback && callback(new Error(res.errMsg), null);
             }
         },
         fail: function (res) {
+            console.warn("Download file failed: " + remoteUrl);
             console.warn(res.errMsg);
             callback && callback(new Error(res.errMsg), null);
         }


### PR DESCRIPTION
adapter里面适配XMLHttpRequest时，默认以json格式来下载，然后又stringify为text，用户又parse为json，浪费时间，甚至崩溃，改为除了arraybuffer外，其他默认以text类型来下载，如果是请求json再parse为json，请求text就返回text，减少多余的stringify和parse。

解决论坛里反馈的` cleanAllCaches里，会删除大部分没有使用到的缓存，如果在writeCacheFile的时候，恰好之前也在写这个文件，那么其实最新的cachedFiles并没有被写成功，而在callback里就直接对相关文件进行了删除`, 再加了一个检测，检测是否正在写文件中，对于正在写文件中的时候，callback应该留到下次执行