### PR TITLE
fix audio replay invalid for ios

### DIFF
--- a/wechatgame/libs/engine/Audio.js
+++ b/wechatgame/libs/engine/Audio.js
@@ -2,8 +2,11 @@
     if (!(cc && cc.Audio && cc.sys.platform === cc.sys.ANDROID)) {
         return;
     }
+
     cc.Audio.prototype.stop = function () {
         if (!this._element) return;
+        // 由于 web 端没有 stop 接口，是通过 pause + currentTime = 0 的方式进行 stop 的
+        // 但是在微信小游戏安卓平台上，pause 后是无法设置 currentTime 为 0 的，从而进行适配
         this._element.stop();
         this._element.currentTime = 0;
         this._unbindEnded();

--- a/wechatgame/libs/engine/Audio.js
+++ b/wechatgame/libs/engine/Audio.js
@@ -1,5 +1,5 @@
 (function () {
-    if (!(cc && cc.Audio)) {
+    if (!(cc && cc.Audio && cc.sys.platform === cc.sys.ANDROID)) {
         return;
     }
     cc.Audio.prototype.stop = function () {


### PR DESCRIPTION
之前适配 audio 的 stop，是为了解决安卓平台 stop 音频后 currentTime 无法清零，但是现在的适配层会导致 ios 重新播放音频后无法生效

解决方案：现在只限制与安卓平台才生效该适配代码