### PR TITLE
ensure videoPlayer.currentTime is at the end of duration

### DIFF
--- a/wechatgame/libs/engine/VideoPlayer.js
+++ b/wechatgame/libs/engine/VideoPlayer.js
@@ -63,6 +63,7 @@
         video.onEnded(function () {
             if (self._video !== video) return;
             self._playing = false;
+            self._currentTime = self._duration;  // ensure currentTime is at the end of duration
             self._dispatchEvent(_impl.EventType.COMPLETED);
         });
         video.onPause(function () {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1780

changeLog:
- 修复微信小游戏 videoPlayer 播放结束后，currentTime 不正确的问题