### PR TITLE
fix wrong video currentTime on wx Android when calling video.stop()

### DIFF
--- a/wechatgame/libs/engine/VideoPlayer.js
+++ b/wechatgame/libs/engine/VideoPlayer.js
@@ -75,7 +75,7 @@
             self._duration = res.duration;
             self._currentTime = res.position;
         });
-        // onStop not supported
+        // onStop not supported, implemented in promise returned by video.stop call.
     };
 
     _p._unbindEvent = function () {
@@ -196,13 +196,20 @@
     };
 
     _p.stop = function () {
+        let self = this;
         let video = this._video;
         if (!video || !this._visible) return;
 
-        video.stop();
-
-        this._dispatchEvent(_impl.EventType.STOPPED);
-        this._playing = false;
+        video.stop().then(function (res) {
+            if (res.errMsg && !res.errMsg.includes('ok')) {
+                console.error('failed to stop video player');
+                return;
+            }
+            self._currentTime = 0;
+            video.seek(0);  // ensure to set currentTime by 0 when video is stopped
+            self._playing = false;
+            self._dispatchEvent(_impl.EventType.STOPPED);
+        });
     };
 
     _p.setVolume = function (volume) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1820

changeLog:
- 修复安卓端微信小游戏，VideoPlayer 停止播放后，currentTime 没有回到开头